### PR TITLE
Allow multiple sidebars and fixed light background.

### DIFF
--- a/src/components/LNSidebar.vue
+++ b/src/components/LNSidebar.vue
@@ -1,22 +1,13 @@
 <script setup lang="ts">
 import LNSidebarItem from './LNSidebarItem.vue'
-import { computed } from 'vue'
-import { useData, withBase } from 'vitepress'
+import { useSidebar } from 'vitepress/theme'
 
-const { theme } = useData()
-
-const sidebarItems = theme.value.sidebar.map(item => ({
-  text: item.text,
-  items: item.items.map(i => ({
-    ...i,
-    link: withBase(i.link),
-  })),
-}))
+const { sidebarGroups } = useSidebar()
 </script>
 
 <template>
   <nav class="flex flex-col gap-6">
-    <div v-for="{ text, items } in sidebarItems">
+    <div v-for="{ text, items } in sidebarGroups">
       <span class="text-gray-700 dark:text-gray-400 font-bold text-sm">
         {{ text }}
       </span>

--- a/src/components/LNSidebarItem.vue
+++ b/src/components/LNSidebarItem.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useSidebarControl } from '../composables/sidebar'
 import { computed } from 'vue'
+import { withBase } from 'vitepress'
 import type { SidebarLink } from '../types'
 
 const props = defineProps<{
@@ -8,10 +9,11 @@ const props = defineProps<{
 }>()
 
 const { isActiveLink } = useSidebarControl(computed(() => props.item))
+const link = computed(() => withBase(props.item.link))
 </script>
 
 <template>
-  <a :href="item.link"
+  <a :href="link"
     class="text-sm text-gray-500 hover:text-gray-600 border-l border-gray-300/50 dark:border-gray-800 flex items-start pl-4 py-1 hover:border-primary-500 dark:hover:border-gray-700"
     :class="{
       '!text-primary-500 !border-primary-500': isActiveLink,

--- a/src/composables/prev-next.ts
+++ b/src/composables/prev-next.ts
@@ -1,16 +1,16 @@
 import { computed } from 'vue'
 import { useData } from 'vitepress'
+import { useSidebar } from 'vitepress/theme'
 import { getFlatSideBarLinks } from '../support/sidebar'
 import { isActive } from './outline'
 import type { SidebarLink } from '../types'
 
 export function usePrevNext() {
-  const { page, theme } = useData()
+  const { page } = useData()
+  const { sidebarGroups } = useSidebar()
 
   return computed(() => {
-    const sidebar = theme.value.sidebar
-
-    const candidates = getFlatSideBarLinks(sidebar)
+    const candidates = getFlatSideBarLinks(sidebarGroups.value)
 
     const index = candidates.findIndex(function (link: SidebarLink) {
       return isActive(page.value.relativePath, link.link)

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+    --vp-c-bg: theme(colors.gray.50) !important;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --vp-c-bg: theme(colors.gray.900) !important;
+    }
+}
+
 html.dark {
     color-scheme: dark;
 }

--- a/src/support/sidebar.ts
+++ b/src/support/sidebar.ts
@@ -1,12 +1,12 @@
 import type { SidebarItem, SidebarLink } from '../types'
 
-export function getFlatSideBarLinks(sidebar: SidebarItem[]): SidebarLink[] {
+export function getFlatSideBarLinks(sidebarGroups: SidebarItem[]): SidebarLink[] {
   let links: SidebarLink[] = []
 
-  for (const group of sidebar) {
-    for (const item of group.items) {
-      links.push(item)
-    }
+  for (const { items } of sidebarGroups) {
+    items.forEach(value => {
+      links.push(value)
+    })
   }
 
   return links


### PR DESCRIPTION
Vitepress also allows `sidebar` to be either `Array` or `Object`: https://vitepress.dev/reference/default-theme-sidebar#multiple-sidebars

This allows us to have different sidebar depending on what's version we currently browsing:

```js
{
  themeConfig: {
    sidebar: {
      "/3.0/": [ { /* .... */ } ],
      "/4.0/": [ { /* .... */ } ]
    }
  }
}
```

Also includes CSS changes to override `--vp-c-bg` variable. 

#### Before

![CleanShot 2024-05-20 at 16 09 39](https://github.com/davidhemphill/pilgrim-theme/assets/172966/800c71dc-488c-4ee7-aa25-3db564ae06d4) ![CleanShot 2024-05-20 at 16 09 45](https://github.com/davidhemphill/pilgrim-theme/assets/172966/3fd87aa8-49dd-4468-a147-24e5d732f001)

#### After

![CleanShot 2024-05-20 at 16 10 24](https://github.com/davidhemphill/pilgrim-theme/assets/172966/45d8b3a9-fc8e-4a12-b874-442158546768) ![CleanShot 2024-05-20 at 16 10 19](https://github.com/davidhemphill/pilgrim-theme/assets/172966/37c436ab-7434-4124-a0d6-b6d64ec1670b)

